### PR TITLE
Optimize fetch user query

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,7 +1,7 @@
 class RegistrationsController < Devise::RegistrationsController
 
   def update
-    @user = User.find(current_user.id)
+    @user = current_user
 
     if @user.update_with_password(devise_parameter_sanitizer.sanitize(:account_update))
       set_flash_message :notice, :updated


### PR DESCRIPTION
`current_user` already contains user record. There is no need to fetch
it by `id` again
